### PR TITLE
The link to the "Emulating 'self types' using Java Generics to simpli…

### DIFF
--- a/src/main/java/org/assertj/db/api/AbstractAssert.java
+++ b/src/main/java/org/assertj/db/api/AbstractAssert.java
@@ -21,7 +21,7 @@ import org.assertj.core.description.Description;
  * 
  * @author Régis Pouiller
  * 
- * @param <E> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <E> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *          target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *          for more details.
  */

--- a/src/main/java/org/assertj/db/api/AbstractAssertWithOrigin.java
+++ b/src/main/java/org/assertj/db/api/AbstractAssertWithOrigin.java
@@ -19,7 +19,7 @@ import org.assertj.db.api.origin.Origin;
  * 
  * @author Régis Pouiller
  * 
- * @param <E> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <E> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *          target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *          for more details.
  * @param <O> The type of the assertion class of {@link org.assertj.db.api.origin.Origin}.

--- a/src/main/java/org/assertj/db/api/AbstractAssertWithOriginWithChanges.java
+++ b/src/main/java/org/assertj/db/api/AbstractAssertWithOriginWithChanges.java
@@ -20,7 +20,7 @@ import org.assertj.db.api.origin.OriginWithChanges;
  * Base class for all assertions with an {@link org.assertj.db.api.origin.Origin}
  * and have {@link org.assertj.db.type.Changes}.
  *
- * @param <E> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <E> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *            target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *            for more details.
  * @param <O> The type of the assertion class of {@link org.assertj.db.api.origin.Origin}.

--- a/src/main/java/org/assertj/db/api/AbstractAssertWithOriginWithColumnsAndRows.java
+++ b/src/main/java/org/assertj/db/api/AbstractAssertWithOriginWithColumnsAndRows.java
@@ -21,7 +21,7 @@ import org.assertj.db.type.AbstractDbData;
  * Base class for all assertions with an {@link org.assertj.db.api.origin.Origin}
  * and have {@link org.assertj.db.type.Column}s and {@link org.assertj.db.type.Row}s.
  *
- * @param <E>  The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <E>  The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *             target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *             for more details.
  * @param <O>  The type of the assertion class of {@link org.assertj.db.api.origin.Origin}.

--- a/src/main/java/org/assertj/db/api/AbstractAssertWithOriginWithColumnsAndRowsFromChange.java
+++ b/src/main/java/org/assertj/db/api/AbstractAssertWithOriginWithColumnsAndRowsFromChange.java
@@ -21,7 +21,7 @@ import org.assertj.db.api.origin.OriginWithColumnsAndRowsFromChange;
  * Base class for all assertions with an {@link org.assertj.db.api.origin.Origin}
  * and have {@link org.assertj.db.type.Column}s and {@link org.assertj.db.type.Row}s from a {@link org.assertj.db.type.Change}.
  *
- * @param <E> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <E> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *            target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *            for more details.
  * @param <O> The type of the assertion class of {@link org.assertj.db.api.origin.Origin}.

--- a/src/main/java/org/assertj/db/api/AbstractAssertWithValues.java
+++ b/src/main/java/org/assertj/db/api/AbstractAssertWithValues.java
@@ -24,7 +24,7 @@ import org.assertj.db.type.ValueType;
 /**
  * Base class for all values from a {@link org.assertj.db.type.Change} assertions.
  *
- * @param <E> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <E> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *            target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *            for more details.
  * @param <O> The type of the assertion class of {@link org.assertj.db.api.origin.Origin}.

--- a/src/main/java/org/assertj/db/api/assertions/AssertOnChangeType.java
+++ b/src/main/java/org/assertj/db/api/assertions/AssertOnChangeType.java
@@ -18,7 +18,7 @@ import org.assertj.db.type.ChangeType;
  * Defines the assertion methods on the type of a change (creation, modification or deletion of a row).
  * <p>The different type of changes are enumerated in {@link org.assertj.db.type.ChangeType}.</p>
  *
- * @param <T> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <T> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *            target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *            for more details.
  * @author Régis Pouiller

--- a/src/main/java/org/assertj/db/api/assertions/AssertOnColumnEquality.java
+++ b/src/main/java/org/assertj/db/api/assertions/AssertOnColumnEquality.java
@@ -19,7 +19,7 @@ import org.assertj.db.type.TimeValue;
 /**
  * Defines the assertion methods on the equality of a column.
  *
- * @param <T> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <T> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *            target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *            for more details.
  * @author Régis Pouiller

--- a/src/main/java/org/assertj/db/api/assertions/AssertOnColumnName.java
+++ b/src/main/java/org/assertj/db/api/assertions/AssertOnColumnName.java
@@ -15,7 +15,7 @@ package org.assertj.db.api.assertions;
 /**
  * Defines the assertion method on the name of a column.
  *
- * @param <T> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <T> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *            target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *            for more details.
  * @author Régis Pouiller

--- a/src/main/java/org/assertj/db/api/assertions/AssertOnColumnNullity.java
+++ b/src/main/java/org/assertj/db/api/assertions/AssertOnColumnNullity.java
@@ -15,7 +15,7 @@ package org.assertj.db.api.assertions;
 /**
  * Defines the assertion methods on the nullity of a values of a column.
  *
- * @param <T> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <T> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *            target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *            for more details.
  * @author Régis Pouiller

--- a/src/main/java/org/assertj/db/api/assertions/AssertOnColumnOfChangeEquality.java
+++ b/src/main/java/org/assertj/db/api/assertions/AssertOnColumnOfChangeEquality.java
@@ -19,7 +19,7 @@ import org.assertj.db.type.TimeValue;
 /**
  * Defines the assertion methods on the equality of a column of a change.
  *
- * @param <T> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <T> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *            target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *            for more details.
  * @author Régis Pouiller

--- a/src/main/java/org/assertj/db/api/assertions/AssertOnColumnType.java
+++ b/src/main/java/org/assertj/db/api/assertions/AssertOnColumnType.java
@@ -18,7 +18,7 @@ import org.assertj.db.type.ValueType;
  * Defines the assertion methods on the type of a column.
  * <p>The different type of values are enumerated in {@link org.assertj.db.type.ValueType}.</p>
  *
- * @param <T> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <T> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *            target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *            for more details.
  * @author Régis Pouiller

--- a/src/main/java/org/assertj/db/api/assertions/AssertOnDataType.java
+++ b/src/main/java/org/assertj/db/api/assertions/AssertOnDataType.java
@@ -18,7 +18,7 @@ import org.assertj.db.type.DataType;
  * Defines the assertion methods on the type of data (from a table or from a request).
  * <p>The different type of data are enumerated in {@link org.assertj.db.type.DataType}.</p>
  *
- * @param <T> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <T> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *            target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *            for more details.
  * @author Régis Pouiller

--- a/src/main/java/org/assertj/db/api/assertions/AssertOnModifiedColumn.java
+++ b/src/main/java/org/assertj/db/api/assertions/AssertOnModifiedColumn.java
@@ -15,7 +15,7 @@ package org.assertj.db.api.assertions;
 /**
  * Defines the assertion methods on a modified column.
  *
- * @param <T> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <T> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *            target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *            for more details.
  * @author Régis Pouiller

--- a/src/main/java/org/assertj/db/api/assertions/AssertOnModifiedColumns.java
+++ b/src/main/java/org/assertj/db/api/assertions/AssertOnModifiedColumns.java
@@ -15,7 +15,7 @@ package org.assertj.db.api.assertions;
 /**
  * Defines the assertion methods on modified columns.
  *
- * @param <T> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <T> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *            target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *            for more details.
  * @author Régis Pouiller

--- a/src/main/java/org/assertj/db/api/assertions/AssertOnNumberOfChanges.java
+++ b/src/main/java/org/assertj/db/api/assertions/AssertOnNumberOfChanges.java
@@ -15,7 +15,7 @@ package org.assertj.db.api.assertions;
 /**
  * Defines the assertion method on the number of changes.
  *
- * @param <T> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <T> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *            target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *            for more details.
  * @author Régis Pouiller

--- a/src/main/java/org/assertj/db/api/assertions/AssertOnNumberOfColumns.java
+++ b/src/main/java/org/assertj/db/api/assertions/AssertOnNumberOfColumns.java
@@ -15,7 +15,7 @@ package org.assertj.db.api.assertions;
 /**
  * Defines the assertion method on the number of columns.
  *
- * @param <T> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <T> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *            target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *            for more details.
  * @author Régis Pouiller

--- a/src/main/java/org/assertj/db/api/assertions/AssertOnNumberOfRows.java
+++ b/src/main/java/org/assertj/db/api/assertions/AssertOnNumberOfRows.java
@@ -15,7 +15,7 @@ package org.assertj.db.api.assertions;
 /**
  * Defines the assertion method on the number of rows.
  *
- * @param <T> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <T> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *            target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *            for more details.
  * @author Régis Pouiller

--- a/src/main/java/org/assertj/db/api/assertions/AssertOnPrimaryKey.java
+++ b/src/main/java/org/assertj/db/api/assertions/AssertOnPrimaryKey.java
@@ -15,7 +15,7 @@ package org.assertj.db.api.assertions;
 /**
  * Defines the assertion methods on a primary key.
  *
- * @param <T> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <T> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *            target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *            for more details.
  * @author Régis Pouiller

--- a/src/main/java/org/assertj/db/api/assertions/AssertOnRowEquality.java
+++ b/src/main/java/org/assertj/db/api/assertions/AssertOnRowEquality.java
@@ -15,7 +15,7 @@ package org.assertj.db.api.assertions;
 /**
  * Defines the assertion method on the equality of a row.
  *
- * @param <T> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <T> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *            target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *            for more details.
  * @author Régis Pouiller

--- a/src/main/java/org/assertj/db/api/assertions/AssertOnRowOfChangeExistence.java
+++ b/src/main/java/org/assertj/db/api/assertions/AssertOnRowOfChangeExistence.java
@@ -15,7 +15,7 @@ package org.assertj.db.api.assertions;
 /**
  * Defines the assertion method on the existence of a row of a change.
  *
- * @param <T> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <T> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *            target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *            for more details.
  * @author Régis Pouiller

--- a/src/main/java/org/assertj/db/api/assertions/AssertOnValueChronology.java
+++ b/src/main/java/org/assertj/db/api/assertions/AssertOnValueChronology.java
@@ -19,7 +19,7 @@ import org.assertj.db.type.TimeValue;
 /**
  * Defines the assertion methods on the chronology of a value.
  *
- * @param <T> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <T> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *            target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *            for more details.
  * @author Régis Pouiller

--- a/src/main/java/org/assertj/db/api/assertions/AssertOnValueComparison.java
+++ b/src/main/java/org/assertj/db/api/assertions/AssertOnValueComparison.java
@@ -15,7 +15,7 @@ package org.assertj.db.api.assertions;
 /**
  * Defines the assertion methods on comparisons with a value.
  *
- * @param <T> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <T> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *            target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *            for more details.
  * @author Régis Pouiller

--- a/src/main/java/org/assertj/db/api/assertions/AssertOnValueEquality.java
+++ b/src/main/java/org/assertj/db/api/assertions/AssertOnValueEquality.java
@@ -19,7 +19,7 @@ import org.assertj.db.type.TimeValue;
 /**
  * Defines the assertion methods on the equality of a value.
  *
- * @param <T> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <T> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *            target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *            for more details.
  * @author Régis Pouiller

--- a/src/main/java/org/assertj/db/api/assertions/AssertOnValueNonEquality.java
+++ b/src/main/java/org/assertj/db/api/assertions/AssertOnValueNonEquality.java
@@ -19,7 +19,7 @@ import org.assertj.db.type.TimeValue;
 /**
  * Defines the assertion methods on the non equality of a value.
  *
- * @param <T> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <T> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *            target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *            for more details.
  * @author Régis Pouiller

--- a/src/main/java/org/assertj/db/api/assertions/AssertOnValueNullity.java
+++ b/src/main/java/org/assertj/db/api/assertions/AssertOnValueNullity.java
@@ -15,7 +15,7 @@ package org.assertj.db.api.assertions;
 /**
  * Defines the assertion methods on the nullity of a value.
  *
- * @param <T> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <T> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *            target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *            for more details.
  * @author Régis Pouiller

--- a/src/main/java/org/assertj/db/api/assertions/AssertOnValueType.java
+++ b/src/main/java/org/assertj/db/api/assertions/AssertOnValueType.java
@@ -18,7 +18,7 @@ import org.assertj.db.type.ValueType;
  * Defines the assertion methods on the type of a value.
  * <p>The different type of values are enumerated in {@link org.assertj.db.type.ValueType}.</p>
  *
- * @param <T> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ * @param <T> The "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/1IZIRcY"
  *            target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *            for more details.
  * @author Régis Pouiller


### PR DESCRIPTION
…fy fluent API implementation" blog post is dead, so replace it with a link to the Internet Archive's most recent scrape of the blog post.

Inspired by: https://github.com/joel-costigliola/assertj-core/commit/207611e4a475a6e7ee7a1afa4b6025973022fb57