### PR TITLE
feature: support for non upper case column name

### DIFF
--- a/src/main/java/org/assertj/db/api/Assertions.java
+++ b/src/main/java/org/assertj/db/api/Assertions.java
@@ -17,10 +17,12 @@ import org.assertj.db.type.Changes;
 import org.assertj.db.type.Request;
 import org.assertj.db.type.Source;
 import org.assertj.db.type.Table;
+import org.assertj.db.util.DialectHelper;
 
 import java.io.*;
 
 import static org.assertj.db.util.Descriptions.getDescription;
+import static org.assertj.db.util.DialectHelper.ASSERTJ_DB_DIALECT_PROPERTY_NAME;
 
 /**
  * Entry point of all the assertions.
@@ -138,6 +140,20 @@ public final class Assertions {
   public static ChangesAssert assertThat(Changes changes) {
     return new ChangesAssert(changes).as(getDescription(changes));
   }
+
+  /**
+   * Set current dialect to given one
+   *
+   * @param dialectName dialectName
+   * @return the name of the current dialect
+     */
+  public static String usingDialect(String dialectName){
+    System.setProperty(ASSERTJ_DB_DIALECT_PROPERTY_NAME, dialectName);
+    return System.getProperty(ASSERTJ_DB_DIALECT_PROPERTY_NAME);
+  }
+
+
+
 
   /**
    * Reads the bytes from an {@link InputStream}.

--- a/src/main/java/org/assertj/db/api/ChangeAssert.java
+++ b/src/main/java/org/assertj/db/api/ChangeAssert.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.db.util.Descriptions.*;
+import static org.assertj.db.util.DialectHelper.getColumnName;
 
 /**
  * Assertion methods for a {@link Change}.
@@ -152,7 +153,7 @@ public class ChangeAssert
       throw new NullPointerException("Column name must be not null");
     }
     List<String> columnsNameList = change.getColumnsNameList();
-    int index = columnsNameList.indexOf(columnName.toUpperCase());
+    int index = columnsNameList.indexOf(getColumnName(columnName));
     if (index == -1) {
       throw new AssertJDBException("Column <%s> does not exist", columnName);
     }

--- a/src/main/java/org/assertj/db/api/assertions/impl/AssertionsOnModifiedColumns.java
+++ b/src/main/java/org/assertj/db/api/assertions/impl/AssertionsOnModifiedColumns.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import static org.assertj.db.error.ShouldHaveModifications.shouldHaveModifications;
 import static org.assertj.db.error.ShouldHaveNumberOfModifications.shouldHaveNumberOfModifications;
+import static org.assertj.db.util.DialectHelper.getColumnName;
 
 /**
  * Implements the assertion methods on modified columns.
@@ -133,7 +134,7 @@ public class AssertionsOnModifiedColumns {
       if (name == null) {
         throw new NullPointerException("Column name must be not null");
       }
-      namesList.add(name.toUpperCase());
+      namesList.add(getColumnName(name));
     }
     Collections.sort(namesList);
 

--- a/src/main/java/org/assertj/db/api/assertions/impl/AssertionsOnPrimaryKey.java
+++ b/src/main/java/org/assertj/db/api/assertions/impl/AssertionsOnPrimaryKey.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import static org.assertj.db.error.ShouldHavePksNames.shouldHavePksNames;
 import static org.assertj.db.error.ShouldHavePksValues.shouldHavePksValues;
+import static org.assertj.db.util.DialectHelper.getColumnName;
 
 /**
  * Implements the assertion methods on a primary key.
@@ -75,7 +76,7 @@ public class AssertionsOnPrimaryKey {
       if (name == null) {
         throw new NullPointerException("Column name must be not null");
       }
-      namesList.add(name.toUpperCase());
+      namesList.add(getColumnName(name));
     }
     Collections.sort(namesList);
 

--- a/src/main/java/org/assertj/db/navigation/PositionWithColumns.java
+++ b/src/main/java/org/assertj/db/navigation/PositionWithColumns.java
@@ -15,8 +15,11 @@ package org.assertj.db.navigation;
 import org.assertj.db.exception.AssertJDBException;
 import org.assertj.db.global.AbstractElement;
 import org.assertj.db.type.DbElement;
+import org.assertj.db.util.DialectHelper;
 
 import java.util.List;
+
+import static org.assertj.db.util.DialectHelper.getColumnName;
 
 /**
  * Position with columns during navigation.
@@ -52,7 +55,7 @@ public abstract class PositionWithColumns<E extends AbstractElement & Navigation
     if (columnName == null) {
       throw new NullPointerException("Column name must be not null");
     }
-    int index = columnsNameList.indexOf(columnName.toUpperCase());
+    int index = columnsNameList.indexOf(getColumnName(columnName));
     if (index == -1) {
       throw new AssertJDBException("Column <%s> does not exist", columnName);
     }

--- a/src/main/java/org/assertj/db/type/AbstractDbData.java
+++ b/src/main/java/org/assertj/db/type/AbstractDbData.java
@@ -13,6 +13,7 @@
 package org.assertj.db.type;
 
 import org.assertj.db.exception.AssertJDBException;
+import org.assertj.db.util.DialectHelper;
 import org.assertj.db.util.RowComparator;
 
 import javax.sql.DataSource;
@@ -20,6 +21,8 @@ import java.sql.*;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
+import static org.assertj.db.util.DialectHelper.getColumnName;
 
 /**
  * This class represents data from the database (either a {@link Table} or a {@link Request}).
@@ -281,7 +284,7 @@ public abstract class AbstractDbData<D extends AbstractDbData<D>> extends Abstra
   protected void setPksNameList(List<String> pksNameList) {
     this.pksNameList = new ArrayList<>();
     for (String pkName : pksNameList) {
-      String pkNameUp = pkName.toUpperCase();
+      String pkNameUp = getColumnName(pkName);
       this.pksNameList.add(pkNameUp);
     }
     if (rowsList != null) {

--- a/src/main/java/org/assertj/db/type/Request.java
+++ b/src/main/java/org/assertj/db/type/Request.java
@@ -18,6 +18,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.assertj.db.util.DialectHelper.getColumnName;
+
 /**
  * A request in the database to get values.
  * <p>
@@ -177,7 +179,7 @@ public class Request extends AbstractDbData<Request> {
     List<String> columnsNameList = new ArrayList<>();
     for (int i = 1; i <= resultSetMetaData.getColumnCount(); i++) {
       String columnName = resultSetMetaData.getColumnLabel(i);
-      columnsNameList.add(columnName.toUpperCase());
+      columnsNameList.add(getColumnName(columnName));
     }
     setColumnsNameList(columnsNameList);
     controlIfAllThePksNameExistInTheColumns();

--- a/src/main/java/org/assertj/db/type/Row.java
+++ b/src/main/java/org/assertj/db/type/Row.java
@@ -17,6 +17,8 @@ import org.assertj.db.util.Values;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.assertj.db.util.DialectHelper.getColumnName;
+
 /**
  * Row in a {@link AbstractDbData}.
  * <p>
@@ -189,7 +191,7 @@ public class Row implements DbElement {
     if (columnName == null) {
       throw new NullPointerException("Column name must be not null");
     }
-    String name = columnName.toUpperCase();
+    String name = getColumnName(columnName);
     int index = getColumnsNameList().indexOf(name);
     if (index == -1) {
       return null;

--- a/src/main/java/org/assertj/db/type/Table.java
+++ b/src/main/java/org/assertj/db/type/Table.java
@@ -245,7 +245,7 @@ public class Table extends AbstractDbData<Table> {
 
   /**
    * Returns the SQL request.
-   * 
+   *
    * @see AbstractDbData#getRequest()
    * @return The SQL request.
    * @throws NullPointerException If the {@link #name} field is {@code null}.

--- a/src/main/java/org/assertj/db/type/Table.java
+++ b/src/main/java/org/assertj/db/type/Table.java
@@ -18,6 +18,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.assertj.db.util.DialectHelper.getColumnName;
+
 /**
  * A table in the database to read to get the values.
  * <p>
@@ -33,14 +35,14 @@ import java.util.List;
  * This {@link Table} point to a table called {@code movie} in a H2 database in memory like indicated in the
  * {@link Source}.
  * </p>
- * 
+ *
  * <pre>
  * <code class='java'>
  * Source source = new Source(&quot;jdbc:h2:mem:test&quot;, &quot;sa&quot;, &quot;&quot;);
  * Table table = new Table(source, &quot;movie&quot;);
  * </code>
  * </pre>
- * 
+ *
  * </li>
  * <li>
  * <p>
@@ -50,7 +52,7 @@ import java.util.List;
  * {@code birthday}).<br>
  * The {@link Table} use a {@code DataSource} instead of a {@link Source} like above.
  * </p>
- * 
+ *
  * <pre>
  * <code class='java'>
  * DataSource dataSource = ...;
@@ -58,12 +60,11 @@ import java.util.List;
  * Table table2 = new Table(dataSource, &quot;musician&quot;, null, new String[] { &quot;birthday&quot; });
  * </code>
  * </pre>
- * 
+ *
  * </li>
  * </ul>
- * 
+ *
  * @author Régis Pouiller
- * 
  */
 public class Table extends AbstractDbData<Table> {
 
@@ -89,7 +90,7 @@ public class Table extends AbstractDbData<Table> {
 
   /**
    * Constructor with a {@link Source} and the name of the table.
-   * 
+   *
    * @param source {@link Source} to connect to the database.
    * @param name Name of the table.
    */
@@ -99,13 +100,13 @@ public class Table extends AbstractDbData<Table> {
 
   /**
    * Constructor with a {@link Source}, the name of the table and the columns to check and to exclude.
-   * 
+   *
    * @param source {@link Source} to connect to the database.
    * @param name Name of the table.
    * @param columnsToCheck Array of the name of the columns to check. If {@code null} that means to check all the
-   *          columns.
+   *                       columns.
    * @param columnsToExclude Array of the name of the columns to exclude. If {@code null} that means to exclude no
-   *          column.
+   *                         column.
    */
   public Table(Source source, String name, String[] columnsToCheck, String[] columnsToExclude) {
     super(Table.class, DataType.TABLE, source);
@@ -116,7 +117,7 @@ public class Table extends AbstractDbData<Table> {
 
   /**
    * Constructor with a dataSource and the name of the table.
-   * 
+   *
    * @param dataSource DataSource of the database.
    * @param name Name of the table.
    */
@@ -126,13 +127,13 @@ public class Table extends AbstractDbData<Table> {
 
   /**
    * Constructor with a connection, the name of the table and the columns to check and to exclude.
-   * 
+   *
    * @param dataSource DataSource of the database.
    * @param name Name of the table.
    * @param columnsToCheck Array of the name of the columns to check. If {@code null} that means to check all the
-   *          columns.
+   *        columns.
    * @param columnsToExclude Array of the name of the columns to exclude. If {@code null} that means to exclude no
-   *          column.
+   *        column.
    */
   public Table(DataSource dataSource, String name, String[] columnsToCheck, String[] columnsToExclude) {
     super(Table.class, DataType.TABLE, dataSource);
@@ -143,7 +144,7 @@ public class Table extends AbstractDbData<Table> {
 
   /**
    * Return the name of the table.
-   * 
+   *
    * @see #setName(String)
    * @return the name of the table.
    */
@@ -153,7 +154,7 @@ public class Table extends AbstractDbData<Table> {
 
   /**
    * Sets the name of the table.
-   * 
+   *
    * @see #getName()
    * @param name The name of the table.
    * @return The actual instance.
@@ -166,62 +167,62 @@ public class Table extends AbstractDbData<Table> {
     return this;
   }
 
-  /**
-   * Returns the columns to check (which are present in {@link AbstractDbData#getColumnsNameList()}.
-   * 
-   * @see #setColumnsToCheck(String[])
-   * @return Array of the name of the columns to check. If {@code null} that means to check all the columns.
-   */
-  public String[] getColumnsToCheck() {
-    if (columnsToCheck == null) {
-      return null;
-    }
-    return columnsToCheck.clone();
-  }
-
-  /**
-   * Sets the columns to check (which are present in {@link AbstractDbData#getColumnsNameList()}.
-   * 
-   * @see #getColumnsToCheck()
-   * @param columnsToCheck Array of the name of the columns to check. If {@code null} that means to check all the
-   *          columns.
-   * @return The actual instance.
-   * @throws NullPointerException If one of the name in {@code columnsToCheck} is {@code null}.
-   */
-  public Table setColumnsToCheck(String[] columnsToCheck) {
-    if (columnsToCheck != null) {
-      // If the parameter is not null, all the names are transformed to get upper case
-      // before setting the instance field
-      this.columnsToCheck = new String[columnsToCheck.length];
-      for (int index = 0; index < columnsToCheck.length; index++) {
-        String column = columnsToCheck[index];
-        if (column == null) {
-          throw new NullPointerException("The name of the column can not be null");
-        }
-        this.columnsToCheck[index] = column.toUpperCase();
+    /**
+     * Returns the columns to check (which are present in {@link AbstractDbData#getColumnsNameList()}.
+     *
+     * @see #setColumnsToCheck(String[])
+     * @return Array of the name of the columns to check. If {@code null} that means to check all the columns.
+     */
+    public String[] getColumnsToCheck() {
+      if (columnsToCheck == null) {
+        return null;
       }
-    } else {
-      this.columnsToCheck = null;
+      return columnsToCheck.clone();
     }
-    return this;
-  }
+
+    /**
+     * Sets the columns to check (which are present in {@link AbstractDbData#getColumnsNameList()}.
+     *
+     * @see #getColumnsToCheck()
+     * @param columnsToCheck Array of the name of the columns to check. If {@code null} that means to check all the
+     *                       columns.
+     * @return The actual instance.
+     * @throws NullPointerException If one of the name in {@code columnsToCheck} is {@code null}.
+     */
+    public Table setColumnsToCheck(String[] columnsToCheck) {
+      if (columnsToCheck != null) {
+        // If the parameter is not null, all the names are transformed to get upper case
+        // before setting the instance field
+        this.columnsToCheck = new String[columnsToCheck.length];
+        for (int index = 0; index < columnsToCheck.length; index++) {
+          String column = columnsToCheck[index];
+          if (column == null) {
+            throw new NullPointerException("The name of the column can not be null");
+          }
+          this.columnsToCheck[index] = getColumnName(column);
+        }
+      } else {
+          this.columnsToCheck = null;
+      }
+      return this;
+    }
 
   /**
    * Returns the columns to exclude (which are not present in {@link AbstractDbData#getColumnsNameList()}.
-   * 
+   *
    * @see #setColumnsToExclude(String[])
    * @return The columns.
    */
   public String[] getColumnsToExclude() {
     if (columnsToExclude == null) {
-      return null;
+    return null;
     }
     return columnsToExclude.clone();
   }
 
   /**
    * Sets the columns to exclude (which are not present in {@link AbstractDbData#getColumnsNameList()}.
-   * 
+   *
    * @see #getColumnsToExclude()
    * @param columnsToExclude The columns.
    * @return The actual instance.
@@ -234,10 +235,10 @@ public class Table extends AbstractDbData<Table> {
         if (column == null) {
           throw new NullPointerException("The name of the column can not be null");
         }
-        this.columnsToExclude[index] = column.toUpperCase();
+        this.columnsToExclude[index] = getColumnName(column);
       }
     } else {
-      this.columnsToExclude = null;
+    this.columnsToExclude = null;
     }
     return this;
   }
@@ -263,7 +264,7 @@ public class Table extends AbstractDbData<Table> {
         if (stringBuilder.length() > 7) {
           stringBuilder.append(", ");
         }
-        stringBuilder.append(column);
+      stringBuilder.append(column);
       }
     }
     stringBuilder.append(" FROM ");
@@ -277,7 +278,7 @@ public class Table extends AbstractDbData<Table> {
    * This method use the {@link ResultSetMetaData} from the <code>resultSet</code> parameter to list the name of the
    * columns. But the columns to exclude are not collected.
    * </p>
-   * 
+   *
    * @param resultSet The {@code ResultSet}.
    * @throws SQLException SQL Exception.
    */
@@ -290,10 +291,9 @@ public class Table extends AbstractDbData<Table> {
     }
 
     for (int i = 1; i <= resultSetMetaData.getColumnCount(); i++) {
-      String columnName = resultSetMetaData.getColumnLabel(i).toUpperCase();
+      String columnName = getColumnName(resultSetMetaData.getColumnLabel(i));
       if (columnsToExcludeList == null || !columnsToExcludeList.contains(columnName)) {
-
-        columnsNameList.add(columnName);
+       columnsNameList.add(columnName);
       }
     }
     setColumnsNameList(columnsNameList);
@@ -305,7 +305,7 @@ public class Table extends AbstractDbData<Table> {
    * This method use the {@link DatabaseMetaData} from the {@code Connection} parameter to list the primary keys of the
    * table.
    * </p>
-   * 
+   *
    * @param connection The {@code Connection} to the database.
    * @throws SQLException SQL Exception.
    */
@@ -313,8 +313,8 @@ public class Table extends AbstractDbData<Table> {
     List<String> pksNameList = new ArrayList<>();
     DatabaseMetaData metaData = connection.getMetaData();
 
-    try (ResultSet resultSet = metaData.getPrimaryKeys(getCatalog(connection), getSchema(connection),
-        name.toUpperCase())) {
+    try (ResultSet resultSet = metaData
+       .getPrimaryKeys(getCatalog(connection), getSchema(connection), getColumnName(name))) {
       while (resultSet.next()) {
         String columnName = resultSet.getString("COLUMN_NAME");
         if (getColumnsNameList().indexOf(columnName) != -1) {
@@ -327,11 +327,11 @@ public class Table extends AbstractDbData<Table> {
 
   /**
    * Specific implementation of the loading for a {@code Table}.
-   * 
+   *
    * @see AbstractDbData#loadImpl(Connection)
    * @param connection {@link Connection} to the database provided by {@link AbstractDbData#load()} private method.
    * @throws NullPointerException If the {@link #name} field is {@code null}.
-   * @throws SQLException SQL Exception.
+   * @throws SQLException         SQL Exception.
    */
   @Override
   protected void loadImpl(Connection connection) throws SQLException {

--- a/src/main/java/org/assertj/db/util/DialectHelper.java
+++ b/src/main/java/org/assertj/db/util/DialectHelper.java
@@ -17,11 +17,11 @@ import org.assertj.db.exception.AssertJDBException;
 public class DialectHelper {
 
     public static final String ASSERTJ_DB_DIALECT_PROPERTY_NAME = "ASSERTJ_DB_DIALECT";
-    private static final String ASSERTJ_DB_DIALECT = System.getProperty(ASSERTJ_DB_DIALECT_PROPERTY_NAME);
 
     public static String getColumnName(String name) {
+        String assertj_db_dialect = System.getProperty(ASSERTJ_DB_DIALECT_PROPERTY_NAME);
         if (name == null)
             throw new AssertJDBException("ColumnName is mandatory");
-        return ASSERTJ_DB_DIALECT == null || "H2".equals(ASSERTJ_DB_DIALECT) ? name.toUpperCase() : name;
+        return assertj_db_dialect == null || "H2".equals(assertj_db_dialect) ? name.toUpperCase() : name;
     }
 }

--- a/src/main/java/org/assertj/db/util/DialectHelper.java
+++ b/src/main/java/org/assertj/db/util/DialectHelper.java
@@ -1,0 +1,27 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
+package org.assertj.db.util;
+
+import org.assertj.db.exception.AssertJDBException;
+
+public class DialectHelper {
+
+    public static final String ASSERTJ_DB_DIALECT_PROPERTY_NAME = "ASSERTJ_DB_DIALECT";
+    private static final String ASSERTJ_DB_DIALECT = System.getProperty(ASSERTJ_DB_DIALECT_PROPERTY_NAME);
+
+    public static String getColumnName(String name) {
+        if (name == null)
+            throw new AssertJDBException("ColumnName is mandatory");
+        return ASSERTJ_DB_DIALECT == null || "H2".equals(ASSERTJ_DB_DIALECT) ? name.toUpperCase() : name;
+    }
+}

--- a/src/test/java/org/assertj/db/api/AssertionsTest.java
+++ b/src/test/java/org/assertj/db/api/AssertionsTest.java
@@ -1,0 +1,18 @@
+package org.assertj.db.api;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.db.api.Assertions.usingDialect;
+import static org.assertj.db.util.DialectHelper.ASSERTJ_DB_DIALECT_PROPERTY_NAME;
+
+public class AssertionsTest {
+
+    @Test
+    public void should_pass_if_setting_property_works() throws Exception {
+        String dialect = "H2";
+        assertThat(usingDialect(dialect)).isNotEmpty();
+
+        assertThat(System.getProperty(ASSERTJ_DB_DIALECT_PROPERTY_NAME)).isEqualTo(dialect);
+    }
+}

--- a/src/test/java/org/assertj/db/api/AssertionsTest.java
+++ b/src/test/java/org/assertj/db/api/AssertionsTest.java
@@ -1,3 +1,15 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
 package org.assertj.db.api;
 
 import org.junit.Test;

--- a/src/test/java/org/assertj/db/util/DialectHelperTest.java
+++ b/src/test/java/org/assertj/db/util/DialectHelperTest.java
@@ -1,3 +1,15 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2015 the original author or authors.
+ */
 package org.assertj.db.util;
 
 import org.junit.Test;

--- a/src/test/java/org/assertj/db/util/DialectHelperTest.java
+++ b/src/test/java/org/assertj/db/util/DialectHelperTest.java
@@ -1,0 +1,29 @@
+package org.assertj.db.util;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.db.api.Assertions.usingDialect;
+import static org.assertj.db.util.DialectHelper.getColumnName;
+
+public class DialectHelperTest {
+    @Test
+    public void should_pass_if_DialectHelper_change_column_name_when_using_H2_dialect() throws Exception {
+        usingDialect("H2");
+
+        assertThat(getColumnName("firstName")).isEqualTo("FIRSTNAME");
+    }
+
+    @Test
+    public void should_pass_if_DialectHelper_change_column_name_when_using_no_dialect() throws Exception {
+        assertThat(getColumnName("firstName")).isEqualTo("FIRSTNAME");
+    }
+
+    @Test
+    public void should_pass_if_DialectHelper_do_not_change_column_name_when_using_any_dialect_other_than_H2()
+        throws Exception {
+        usingDialect("MySQL");
+
+        assertThat(getColumnName("firstName")).isEqualTo("firstName");
+    }
+}


### PR DESCRIPTION
add DialectHelper to handle uppercase. For now it is very short but I think it can became an entry point to select dialect strategy.

Add a non-standard entry point keyword "using" in Assertions.

By default, assertj-db is still upper-casing every column name

See #32 #31 