### PR TITLE
Replace Junit4 assertions by AssertJ ones

### DIFF
--- a/src/test/java/org/assertj/db/api/AssertOnColumnOfChangeEquality_HasValues_One_Character_Test.java
+++ b/src/test/java/org/assertj/db/api/AssertOnColumnOfChangeEquality_HasValues_One_Character_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.common.AbstractTest;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnChangeType_IsCreation_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnChangeType_IsCreation_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnChangeType_IsDeletion_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnChangeType_IsDeletion_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnChangeType_IsModification_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnChangeType_IsModification_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnChangeType_IsOfType_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnChangeType_IsOfType_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnClass_IsOfClass_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnClass_IsOfClass_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnContent_ContainsValues_Boolean_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnContent_ContainsValues_Boolean_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.TableColumnAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnContent_ContainsValues_Bytes_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnContent_ContainsValues_Bytes_Test.java
@@ -12,9 +12,9 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
 import static org.assertj.db.api.Assertions.bytesContentFromClassPathOf;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.TableColumnAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnContent_ContainsValues_Character_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnContent_ContainsValues_Character_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.TableColumnAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnContent_ContainsValues_DateTimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnContent_ContainsValues_DateTimeValue_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.TableColumnAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnContent_ContainsValues_DateValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnContent_ContainsValues_DateValue_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.TableColumnAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnContent_ContainsValues_Number_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnContent_ContainsValues_Number_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.TableColumnAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnContent_ContainsValues_String_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnContent_ContainsValues_String_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.TableColumnAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnContent_HasValues_TimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnContent_HasValues_TimeValue_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.TableColumnAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnContent_HasValues_UUID_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnContent_HasValues_UUID_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import java.util.UUID;
 

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnEquality_HasValues_Boolean_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnEquality_HasValues_Boolean_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.TableColumnAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnEquality_HasValues_Bytes_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnEquality_HasValues_Bytes_Test.java
@@ -12,9 +12,9 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
 import static org.assertj.db.api.Assertions.bytesContentFromClassPathOf;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.TableColumnAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnEquality_HasValues_Character_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnEquality_HasValues_Character_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.TableColumnAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnEquality_HasValues_DateTimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnEquality_HasValues_DateTimeValue_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.TableColumnAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnEquality_HasValues_DateValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnEquality_HasValues_DateValue_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.TableColumnAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnEquality_HasValues_Number_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnEquality_HasValues_Number_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.TableColumnAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnEquality_HasValues_String_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnEquality_HasValues_String_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.TableColumnAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnEquality_HasValues_TimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnEquality_HasValues_TimeValue_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.TableColumnAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnEquality_HasValues_UUID_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnEquality_HasValues_UUID_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import java.util.UUID;
 

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnName_HasColumnName_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnName_HasColumnName_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnNullity_HasOnlyNotNullValues_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnNullity_HasOnlyNotNullValues_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.TableColumnAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnNullity_HasOnlyNullValues_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnNullity_HasOnlyNullValues_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.TableColumnAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnOfChangeEquality_HasValues_One_Boolean_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnOfChangeEquality_HasValues_One_Boolean_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnOfChangeEquality_HasValues_One_Bytes_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnOfChangeEquality_HasValues_One_Bytes_Test.java
@@ -12,9 +12,9 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
 import static org.assertj.db.api.Assertions.bytesContentFromClassPathOf;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnOfChangeEquality_HasValues_One_DateTimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnOfChangeEquality_HasValues_One_DateTimeValue_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnOfChangeEquality_HasValues_One_DateValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnOfChangeEquality_HasValues_One_DateValue_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnOfChangeEquality_HasValues_One_Number_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnOfChangeEquality_HasValues_One_Number_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnOfChangeEquality_HasValues_One_String_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnOfChangeEquality_HasValues_One_String_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnOfChangeEquality_HasValues_One_TimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnOfChangeEquality_HasValues_One_TimeValue_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnOfChangeEquality_HasValues_One_UUID_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnOfChangeEquality_HasValues_One_UUID_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import java.util.UUID;
 

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnOfChangeEquality_HasValues_Two_Boolean_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnOfChangeEquality_HasValues_Two_Boolean_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnOfChangeEquality_HasValues_Two_Bytes_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnOfChangeEquality_HasValues_Two_Bytes_Test.java
@@ -12,9 +12,9 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
 import static org.assertj.db.api.Assertions.bytesContentFromClassPathOf;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnOfChangeEquality_HasValues_Two_Character_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnOfChangeEquality_HasValues_Two_Character_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnOfChangeEquality_HasValues_Two_DateTimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnOfChangeEquality_HasValues_Two_DateTimeValue_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnOfChangeEquality_HasValues_Two_DateValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnOfChangeEquality_HasValues_Two_DateValue_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnOfChangeEquality_HasValues_Two_Number_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnOfChangeEquality_HasValues_Two_Number_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnOfChangeEquality_HasValues_Two_String_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnOfChangeEquality_HasValues_Two_String_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnOfChangeEquality_HasValues_Two_TimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnOfChangeEquality_HasValues_Two_TimeValue_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnOfChangeEquality_HasValues_Two_UUID_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnOfChangeEquality_HasValues_Two_UUID_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import java.util.UUID;
 

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnType_IsBoolean_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnType_IsBoolean_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnType_IsBytes_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnType_IsBytes_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnType_IsDateTime_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnType_IsDateTime_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnType_IsDate_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnType_IsDate_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnType_IsNumber_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnType_IsNumber_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnType_IsOfAnyTypeIn_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnType_IsOfAnyTypeIn_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnType_IsOfType_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnType_IsOfType_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnType_IsText_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnType_IsText_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnType_IsTime_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnType_IsTime_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnColumnType_IsUUID_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnColumnType_IsUUID_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnDataType_IsOnDataType_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnDataType_IsOnDataType_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnDataType_IsOnRequest_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnDataType_IsOnRequest_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnDataType_IsOnTable_Name_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnDataType_IsOnTable_Name_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnDataType_IsOnTable_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnDataType_IsOnTable_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnExistence_DoesNotExist_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnExistence_DoesNotExist_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.TableAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnExistence_Exists_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnExistence_Exists_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.TableAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnModifiedColumn_IsModified_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnModifiedColumn_IsModified_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnModifiedColumn_IsNotModified_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnModifiedColumn_IsNotModified_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnModifiedColumns_HasModifiedColumns_Integer_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnModifiedColumns_HasModifiedColumns_Integer_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnModifiedColumns_HasModifiedColumns_String_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnModifiedColumns_HasModifiedColumns_String_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnModifiedColumns_HasNumberOfModifiedColumnsGreaterThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnModifiedColumns_HasNumberOfModifiedColumnsGreaterThanOrEqualTo_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnModifiedColumns_HasNumberOfModifiedColumnsGreaterThan_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnModifiedColumns_HasNumberOfModifiedColumnsGreaterThan_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnModifiedColumns_HasNumberOfModifiedColumnsLessThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnModifiedColumns_HasNumberOfModifiedColumnsLessThanOrEqualTo_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnModifiedColumns_HasNumberOfModifiedColumnsLessThan_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnModifiedColumns_HasNumberOfModifiedColumnsLessThan_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnModifiedColumns_HasNumberOfModifiedColumns_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnModifiedColumns_HasNumberOfModifiedColumns_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnNumberOfChanges_HasNumberOfChangesGreaterThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnNumberOfChanges_HasNumberOfChangesGreaterThanOrEqualTo_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangesAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnNumberOfChanges_HasNumberOfChangesGreaterThan_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnNumberOfChanges_HasNumberOfChangesGreaterThan_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangesAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnNumberOfChanges_HasNumberOfChangesLessThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnNumberOfChanges_HasNumberOfChangesLessThanOrEqualTo_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangesAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnNumberOfChanges_HasNumberOfChangesLessThan_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnNumberOfChanges_HasNumberOfChangesLessThan_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangesAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnNumberOfChanges_HasNumberOfChanges_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnNumberOfChanges_HasNumberOfChanges_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangesAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnNumberOfColumns_HasNumberOfColumnsGreaterThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnNumberOfColumns_HasNumberOfColumnsGreaterThanOrEqualTo_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnNumberOfColumns_HasNumberOfColumnsGreaterThan_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnNumberOfColumns_HasNumberOfColumnsGreaterThan_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnNumberOfColumns_HasNumberOfColumnsLessThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnNumberOfColumns_HasNumberOfColumnsLessThanOrEqualTo_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnNumberOfColumns_HasNumberOfColumnsLessThan_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnNumberOfColumns_HasNumberOfColumnsLessThan_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnNumberOfColumns_HasNumberOfColumns_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnNumberOfColumns_HasNumberOfColumns_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnNumberOfRows_HasNumberOfRowsGreaterThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnNumberOfRows_HasNumberOfRowsGreaterThanOrEqualTo_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.TableAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnNumberOfRows_HasNumberOfRowsGreaterThan_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnNumberOfRows_HasNumberOfRowsGreaterThan_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.TableAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnNumberOfRows_HasNumberOfRowsLessThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnNumberOfRows_HasNumberOfRowsLessThanOrEqualTo_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.TableAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnNumberOfRows_HasNumberOfRowsLessThan_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnNumberOfRows_HasNumberOfRowsLessThan_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.TableAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnNumberOfRows_HasNumberOfRows_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnNumberOfRows_HasNumberOfRows_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.TableAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnNumberOfRows_IsEmpty_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnNumberOfRows_IsEmpty_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.TableAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnPrimaryKey_HasPksNames_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnPrimaryKey_HasPksNames_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnPrimaryKey_HasPksValues_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnPrimaryKey_HasPksValues_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnRowNullity_HasOnlyNotNullValues_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnRowNullity_HasOnlyNotNullValues_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.TableRowAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsAfterOrEqualTo_DateTimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsAfterOrEqualTo_DateTimeValue_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import java.text.ParseException;
 

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsAfterOrEqualTo_DateValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsAfterOrEqualTo_DateValue_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import java.text.ParseException;
 

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsAfterOrEqualTo_LocalDateTime_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsAfterOrEqualTo_LocalDateTime_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import java.time.LocalDateTime;
 

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsAfterOrEqualTo_LocalDate_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsAfterOrEqualTo_LocalDate_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import java.time.LocalDate;
 

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsAfterOrEqualTo_LocalTime_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsAfterOrEqualTo_LocalTime_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import java.time.LocalTime;
 

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsAfterOrEqualTo_String_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsAfterOrEqualTo_String_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsAfterOrEqualTo_TimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsAfterOrEqualTo_TimeValue_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import java.text.ParseException;
 

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsAfter_DateTimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsAfter_DateTimeValue_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import java.text.ParseException;
 

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsAfter_DateValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsAfter_DateValue_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import java.text.ParseException;
 

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsAfter_LocalDateTime_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsAfter_LocalDateTime_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import java.time.LocalDateTime;
 

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsAfter_LocalDate_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsAfter_LocalDate_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import java.time.LocalDate;
 

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsAfter_LocalTime_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsAfter_LocalTime_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import java.time.LocalTime;
 

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsAfter_String_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsAfter_String_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsAfter_TimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsAfter_TimeValue_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import java.text.ParseException;
 

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsBeforeOrEqualTo_DateTimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsBeforeOrEqualTo_DateTimeValue_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import java.text.ParseException;
 

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsBeforeOrEqualTo_DateValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsBeforeOrEqualTo_DateValue_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import java.text.ParseException;
 

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsBeforeOrEqualTo_LocalDateTime_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsBeforeOrEqualTo_LocalDateTime_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import java.time.LocalDateTime;
 

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsBeforeOrEqualTo_LocalDate_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsBeforeOrEqualTo_LocalDate_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import java.time.LocalDate;
 

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsBeforeOrEqualTo_LocalTime_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsBeforeOrEqualTo_LocalTime_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import java.time.LocalTime;
 

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsBeforeOrEqualTo_String_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsBeforeOrEqualTo_String_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsBeforeOrEqualTo_TimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsBeforeOrEqualTo_TimeValue_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import java.text.ParseException;
 

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsBefore_DateTimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsBefore_DateTimeValue_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import java.text.ParseException;
 

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsBefore_DateValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsBefore_DateValue_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import java.text.ParseException;
 

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsBefore_LocalDateTime_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsBefore_LocalDateTime_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import java.time.LocalDateTime;
 

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsBefore_LocalDate_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsBefore_LocalDate_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import java.time.LocalDate;
 

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsBefore_LocalTime_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsBefore_LocalTime_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import java.time.LocalTime;
 

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsBefore_String_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsBefore_String_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsBefore_TimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueChronology_IsBefore_TimeValue_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import java.text.ParseException;
 

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueClass_IsOfClass_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueClass_IsOfClass_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueCloseness_IsCloseTo_DateTimeValue_DateTimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueCloseness_IsCloseTo_DateTimeValue_DateTimeValue_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueCloseness_IsCloseTo_DateTimeValue_DateValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueCloseness_IsCloseTo_DateTimeValue_DateValue_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueCloseness_IsCloseTo_DateTimeValue_TimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueCloseness_IsCloseTo_DateTimeValue_TimeValue_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueCloseness_IsCloseTo_DateValue_DateTimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueCloseness_IsCloseTo_DateValue_DateTimeValue_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueCloseness_IsCloseTo_DateValue_DateValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueCloseness_IsCloseTo_DateValue_DateValue_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueCloseness_IsCloseTo_DateValue_TimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueCloseness_IsCloseTo_DateValue_TimeValue_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueCloseness_IsCloseTo_Number_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueCloseness_IsCloseTo_Number_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueCloseness_IsCloseTo_TimeValue_TimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueCloseness_IsCloseTo_TimeValue_TimeValue_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueComparison_IsGreaterThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueComparison_IsGreaterThanOrEqualTo_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueComparison_IsGreaterThan_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueComparison_IsGreaterThan_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueComparison_IsLessThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueComparison_IsLessThanOrEqualTo_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueComparison_IsLessThan_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueComparison_IsLessThan_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueCondition_DoesNotHave_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueCondition_DoesNotHave_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.Condition;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueCondition_Has_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueCondition_Has_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.Condition;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueCondition_IsNot_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueCondition_IsNot_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.Condition;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueCondition_Is_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueCondition_Is_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.Condition;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueCondition_Satisfies_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueCondition_Satisfies_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.Condition;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueEquality_IsEqualTo_Boolean_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueEquality_IsEqualTo_Boolean_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueEquality_IsEqualTo_Bytes_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueEquality_IsEqualTo_Bytes_Test.java
@@ -12,9 +12,9 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
 import static org.assertj.db.api.Assertions.bytesContentFromClassPathOf;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueEquality_IsEqualTo_Character_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueEquality_IsEqualTo_Character_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueEquality_IsEqualTo_DateTimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueEquality_IsEqualTo_DateTimeValue_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueEquality_IsEqualTo_DateValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueEquality_IsEqualTo_DateValue_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueEquality_IsEqualTo_LocalDateTime_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueEquality_IsEqualTo_LocalDateTime_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import java.time.LocalDateTime;
 

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueEquality_IsEqualTo_LocalDate_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueEquality_IsEqualTo_LocalDate_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import java.time.LocalDate;
 

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueEquality_IsEqualTo_LocalTime_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueEquality_IsEqualTo_LocalTime_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import java.time.LocalTime;
 

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueEquality_IsEqualTo_Number_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueEquality_IsEqualTo_Number_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueEquality_IsEqualTo_Object_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueEquality_IsEqualTo_Object_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueEquality_IsEqualTo_String_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueEquality_IsEqualTo_String_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueEquality_IsEqualTo_TimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueEquality_IsEqualTo_TimeValue_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueEquality_IsEqualTo_UUID_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueEquality_IsEqualTo_UUID_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import java.util.UUID;
 

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueEquality_IsFalse_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueEquality_IsFalse_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueEquality_IsTrue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueEquality_IsTrue_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueEquality_IsZero_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueEquality_IsZero_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueInequality_IsNotEqualTo_Boolean_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueInequality_IsNotEqualTo_Boolean_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueInequality_IsNotEqualTo_Bytes_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueInequality_IsNotEqualTo_Bytes_Test.java
@@ -12,9 +12,9 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
 import static org.assertj.db.api.Assertions.bytesContentFromClassPathOf;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueInequality_IsNotEqualTo_Character_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueInequality_IsNotEqualTo_Character_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueInequality_IsNotEqualTo_DateTimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueInequality_IsNotEqualTo_DateTimeValue_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueInequality_IsNotEqualTo_DateValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueInequality_IsNotEqualTo_DateValue_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueInequality_IsNotEqualTo_LocalDateTime_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueInequality_IsNotEqualTo_LocalDateTime_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import java.time.LocalDateTime;
 

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueInequality_IsNotEqualTo_LocalDate_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueInequality_IsNotEqualTo_LocalDate_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import java.time.LocalDate;
 

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueInequality_IsNotEqualTo_LocalTime_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueInequality_IsNotEqualTo_LocalTime_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import java.time.LocalTime;
 

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueInequality_IsNotEqualTo_Number_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueInequality_IsNotEqualTo_Number_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueInequality_IsNotEqualTo_Object_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueInequality_IsNotEqualTo_Object_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueInequality_IsNotEqualTo_String_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueInequality_IsNotEqualTo_String_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueInequality_IsNotEqualTo_TimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueInequality_IsNotEqualTo_TimeValue_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueInequality_IsNotEqualTo_UUID_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueInequality_IsNotEqualTo_UUID_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import java.util.UUID;
 

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueInequality_IsNotZero_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueInequality_IsNotZero_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueNullity_IsNotNull_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueNullity_IsNotNull_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueNullity_IsNull_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueNullity_IsNull_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueType_IsBoolean_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueType_IsBoolean_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueType_IsBytes_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueType_IsBytes_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueType_IsDateTime_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueType_IsDateTime_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueType_IsDate_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueType_IsDate_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueType_IsNumber_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueType_IsNumber_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueType_IsOfAnyTypeIn_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueType_IsOfAnyTypeIn_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueType_IsOfType_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueType_IsOfType_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueType_IsText_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueType_IsText_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueType_IsTime_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueType_IsTime_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/AssertOnValueType_IsUUID_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/AssertOnValueType_IsUUID_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.api.assertions;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.api.ChangeColumnValueAssert;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnChangeType_IsCreation_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnChangeType_IsCreation_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnChangeType_IsDeletion_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnChangeType_IsDeletion_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnChangeType_IsModification_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnChangeType_IsModification_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnChangeType_IsOfType_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnChangeType_IsOfType_Test.java
@@ -13,7 +13,7 @@
 package org.assertj.db.api.assertions.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.WritableAssertionInfo;
 import org.assertj.db.api.TableAssert;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnClass_IsOfClass_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnClass_IsOfClass_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnContent_ContainsValues_Boolean_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnContent_ContainsValues_Boolean_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnContent_ContainsValues_Bytes_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnContent_ContainsValues_Bytes_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnContent_ContainsValues_Character_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnContent_ContainsValues_Character_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnContent_ContainsValues_DateTimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnContent_ContainsValues_DateTimeValue_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnContent_ContainsValues_DateValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnContent_ContainsValues_DateValue_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.util.ArrayList;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnContent_ContainsValues_Number_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnContent_ContainsValues_Number_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnContent_ContainsValues_Object_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnContent_ContainsValues_Object_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnContent_ContainsValues_String_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnContent_ContainsValues_String_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnContent_ContainsValues_TimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnContent_ContainsValues_TimeValue_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Time;
 import java.util.ArrayList;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnContent_ContainsValues_UUID_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnContent_ContainsValues_UUID_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnEquality_HasValues_Boolean_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnEquality_HasValues_Boolean_Test.java
@@ -13,7 +13,7 @@
 package org.assertj.db.api.assertions.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnEquality_HasValues_Bytes_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnEquality_HasValues_Bytes_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnEquality_HasValues_Character_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnEquality_HasValues_Character_Test.java
@@ -13,7 +13,7 @@
 package org.assertj.db.api.assertions.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnEquality_HasValues_DateTimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnEquality_HasValues_DateTimeValue_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.sql.Timestamp;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnEquality_HasValues_DateValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnEquality_HasValues_DateValue_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.sql.Timestamp;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnEquality_HasValues_Number_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnEquality_HasValues_Number_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnEquality_HasValues_Object_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnEquality_HasValues_Object_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnEquality_HasValues_String_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnEquality_HasValues_String_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.sql.Time;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnEquality_HasValues_TimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnEquality_HasValues_TimeValue_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Time;
 import java.util.ArrayList;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnEquality_HasValues_UUID_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnEquality_HasValues_UUID_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnName_HasColumnName_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnName_HasColumnName_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeClass_IsOfClass_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeClass_IsOfClass_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeEquality_HasValues_One_Boolean_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeEquality_HasValues_One_Boolean_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeEquality_HasValues_One_Bytes_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeEquality_HasValues_One_Bytes_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeEquality_HasValues_One_Character_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeEquality_HasValues_One_Character_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeEquality_HasValues_One_DateTimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeEquality_HasValues_One_DateTimeValue_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.sql.Timestamp;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeEquality_HasValues_One_DateValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeEquality_HasValues_One_DateValue_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.sql.Timestamp;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeEquality_HasValues_One_Number_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeEquality_HasValues_One_Number_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeEquality_HasValues_One_Object_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeEquality_HasValues_One_Object_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.Locale;
 

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeEquality_HasValues_One_String_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeEquality_HasValues_One_String_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.sql.Time;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeEquality_HasValues_One_TimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeEquality_HasValues_One_TimeValue_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Time;
 

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeEquality_HasValues_One_UUID_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeEquality_HasValues_One_UUID_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.UUID;
 

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeEquality_HasValues_Two_Boolean_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeEquality_HasValues_Two_Boolean_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeEquality_HasValues_Two_Bytes_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeEquality_HasValues_Two_Bytes_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeEquality_HasValues_Two_Character_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeEquality_HasValues_Two_Character_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeEquality_HasValues_Two_DateTimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeEquality_HasValues_Two_DateTimeValue_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.sql.Timestamp;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeEquality_HasValues_Two_DateValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeEquality_HasValues_Two_DateValue_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.sql.Timestamp;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeEquality_HasValues_Two_Number_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeEquality_HasValues_Two_Number_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeEquality_HasValues_Two_Objects_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeEquality_HasValues_Two_Objects_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.Locale;
 

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeEquality_HasValues_Two_String_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeEquality_HasValues_Two_String_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.sql.Time;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeEquality_HasValues_Two_TimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeEquality_HasValues_Two_TimeValue_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Time;
 

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeEquality_HasValues_Two_UUID_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeEquality_HasValues_Two_UUID_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.UUID;
 

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeType_IsBoolean_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeType_IsBoolean_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeType_IsBytes_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeType_IsBytes_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeType_IsDateTime_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeType_IsDateTime_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Timestamp;
 

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeType_IsDate_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeType_IsDate_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeType_IsNumber_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeType_IsNumber_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeType_IsOfAnyOfTypes_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeType_IsOfAnyOfTypes_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.Locale;
 

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeType_IsOfType_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeType_IsOfType_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.Locale;
 

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeType_IsText_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeType_IsText_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeType_IsTime_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnOfChangeType_IsTime_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Time;
 

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnType_IsBoolean_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnType_IsBoolean_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnType_IsBytes_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnType_IsBytes_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnType_IsDateTime_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnType_IsDateTime_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnType_IsDate_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnType_IsDate_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.util.ArrayList;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnType_IsNumber_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnType_IsNumber_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnType_IsOfAnyTypeIn_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnType_IsOfAnyTypeIn_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnType_IsOfType_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnType_IsOfType_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnType_IsText_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnType_IsText_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnType_IsTime_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnType_IsTime_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Time;
 import java.util.ArrayList;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnType_IsUUID_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnColumnType_IsUUID_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnDataType_IsOnDataType_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnDataType_IsOnDataType_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnDataType_IsOnRequest_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnDataType_IsOnRequest_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnDataType_IsOnTable_Name_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnDataType_IsOnTable_Name_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnDataType_IsOnTable_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnDataType_IsOnTable_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnModifiedColumn_IsModified_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnModifiedColumn_IsModified_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnModifiedColumn_IsNotModified_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnModifiedColumn_IsNotModified_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnModifiedColumns_HasModifiedColumns_Integer_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnModifiedColumns_HasModifiedColumns_Integer_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.util.Arrays;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnModifiedColumns_HasModifiedColumns_String_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnModifiedColumns_HasModifiedColumns_String_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.util.Arrays;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnModifiedColumns_HasNumberOfModifiedColumnsGreaterThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnModifiedColumns_HasNumberOfModifiedColumnsGreaterThanOrEqualTo_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.util.Arrays;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnModifiedColumns_HasNumberOfModifiedColumnsGreaterThan_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnModifiedColumns_HasNumberOfModifiedColumnsGreaterThan_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.util.Arrays;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnModifiedColumns_HasNumberOfModifiedColumnsLessThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnModifiedColumns_HasNumberOfModifiedColumnsLessThanOrEqualTo_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.util.Arrays;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnModifiedColumns_HasNumberOfModifiedColumnsLessThan_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnModifiedColumns_HasNumberOfModifiedColumnsLessThan_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.util.Arrays;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnModifiedColumns_HasNumberOfModifiedColumns_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnModifiedColumns_HasNumberOfModifiedColumns_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.util.Arrays;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnNumberOfChanges_HasNumberOfChangesGreaterThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnNumberOfChanges_HasNumberOfChangesGreaterThanOrEqualTo_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.util.Arrays;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnNumberOfChanges_HasNumberOfChangesGreaterThan_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnNumberOfChanges_HasNumberOfChangesGreaterThan_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.util.Arrays;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnNumberOfChanges_HasNumberOfChangesLessThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnNumberOfChanges_HasNumberOfChangesLessThanOrEqualTo_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.util.Arrays;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnNumberOfChanges_HasNumberOfChangesLessThan_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnNumberOfChanges_HasNumberOfChangesLessThan_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.util.Arrays;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnNumberOfChanges_HasNumberOfChanges_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnNumberOfChanges_HasNumberOfChanges_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.util.Arrays;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnNumberOfColumns_HasNumberOfColumnsGreaterThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnNumberOfColumns_HasNumberOfColumnsGreaterThanOrEqualTo_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnNumberOfColumns_HasNumberOfColumnsGreaterThan_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnNumberOfColumns_HasNumberOfColumnsGreaterThan_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnNumberOfColumns_HasNumberOfColumnsLessThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnNumberOfColumns_HasNumberOfColumnsLessThanOrEqualTo_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnNumberOfColumns_HasNumberOfColumnsLessThan_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnNumberOfColumns_HasNumberOfColumnsLessThan_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnNumberOfColumns_HasNumberOfColumns_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnNumberOfColumns_HasNumberOfColumns_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnNumberOfRows_HasNumberOfRowsGreaterThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnNumberOfRows_HasNumberOfRowsGreaterThanOrEqualTo_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnNumberOfRows_HasNumberOfRowsGreaterThan_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnNumberOfRows_HasNumberOfRowsGreaterThan_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnNumberOfRows_HasNumberOfRowsLessThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnNumberOfRows_HasNumberOfRowsLessThanOrEqualTo_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnNumberOfRows_HasNumberOfRowsLessThan_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnNumberOfRows_HasNumberOfRowsLessThan_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnNumberOfRows_HasNumberOfRows_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnNumberOfRows_HasNumberOfRows_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnPrimaryKey_HasPksNames_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnPrimaryKey_HasPksNames_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.util.Arrays;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnPrimaryKey_HasPksValues_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnPrimaryKey_HasPksValues_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.util.Arrays;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnRowCondition_HasValues_Satisfying_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnRowCondition_HasValues_Satisfying_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.util.ArrayList;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnRowEquality_HasValues_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnRowEquality_HasValues_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.util.ArrayList;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnRowOfChangeExistence_DoesNotExist_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnRowOfChangeExistence_DoesNotExist_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.util.Arrays;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnRowOfChangeExistence_Exists_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnRowOfChangeExistence_Exists_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.util.Arrays;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnTableExistence_DoesNotExist_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnTableExistence_DoesNotExist_Test.java
@@ -12,18 +12,16 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.SQLException;
 import javax.sql.DataSource;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;
-import org.assertj.db.api.AbstractDbAssert;
 import org.assertj.db.api.TableAssert;
 import org.assertj.db.common.AbstractTest;
 import org.assertj.db.common.DefaultConnectionProvider;
-import org.assertj.db.type.JdbcUrlConnectionProvider;
 import org.junit.Test;
 
 /**

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnTableExistence_Exists_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnTableExistence_Exists_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.SQLException;
 

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueChronology_IsAfterOrEqualTo_DateTimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueChronology_IsAfterOrEqualTo_DateTimeValue_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.sql.Timestamp;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueChronology_IsAfterOrEqualTo_DateValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueChronology_IsAfterOrEqualTo_DateValue_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.sql.Timestamp;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueChronology_IsAfterOrEqualTo_String_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueChronology_IsAfterOrEqualTo_String_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.sql.Time;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueChronology_IsAfterOrEqualTo_TimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueChronology_IsAfterOrEqualTo_TimeValue_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Time;
 

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueChronology_IsAfter_DateTimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueChronology_IsAfter_DateTimeValue_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.sql.Timestamp;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueChronology_IsAfter_DateValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueChronology_IsAfter_DateValue_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.sql.Timestamp;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueChronology_IsAfter_String_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueChronology_IsAfter_String_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.sql.Time;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueChronology_IsAfter_TimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueChronology_IsAfter_TimeValue_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Time;
 

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueChronology_IsBeforeOrEqualTo_DateTimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueChronology_IsBeforeOrEqualTo_DateTimeValue_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.sql.Timestamp;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueChronology_IsBeforeOrEqualTo_DateValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueChronology_IsBeforeOrEqualTo_DateValue_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.sql.Timestamp;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueChronology_IsBeforeOrEqualTo_String_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueChronology_IsBeforeOrEqualTo_String_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.sql.Time;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueChronology_IsBeforeOrEqualTo_TimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueChronology_IsBeforeOrEqualTo_TimeValue_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Time;
 

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueChronology_IsBefore_DateTimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueChronology_IsBefore_DateTimeValue_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.sql.Timestamp;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueChronology_IsBefore_DateValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueChronology_IsBefore_DateValue_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.sql.Timestamp;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueChronology_IsBefore_String_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueChronology_IsBefore_String_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.sql.Time;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueChronology_IsBefore_TimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueChronology_IsBefore_TimeValue_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Time;
 

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueClass_IsOfClass_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueClass_IsOfClass_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueCloseness_IsCloseTo_DateTimeValue_DateTimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueCloseness_IsCloseTo_DateTimeValue_DateTimeValue_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.sql.Timestamp;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueCloseness_IsCloseTo_DateTimeValue_DateValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueCloseness_IsCloseTo_DateTimeValue_DateValue_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.sql.Timestamp;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueCloseness_IsCloseTo_DateTimeValue_TimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueCloseness_IsCloseTo_DateTimeValue_TimeValue_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.sql.Timestamp;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueCloseness_IsCloseTo_DateValue_DateTimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueCloseness_IsCloseTo_DateValue_DateTimeValue_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.sql.Timestamp;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueCloseness_IsCloseTo_DateValue_DateValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueCloseness_IsCloseTo_DateValue_DateValue_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.sql.Timestamp;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueCloseness_IsCloseTo_DateValue_TimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueCloseness_IsCloseTo_DateValue_TimeValue_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.sql.Timestamp;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueCloseness_IsCloseTo_Number_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueCloseness_IsCloseTo_Number_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueCloseness_IsCloseTo_TimeValue_TimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueCloseness_IsCloseTo_TimeValue_TimeValue_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Time;
 

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueComparison_IsGreaterThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueComparison_IsGreaterThanOrEqualTo_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueComparison_IsGreaterThan_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueComparison_IsGreaterThan_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueComparison_IsLessThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueComparison_IsLessThanOrEqualTo_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueComparison_IsLessThan_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueComparison_IsLessThan_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueCondition_IsNot_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueCondition_IsNot_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.Condition;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueCondition_Is_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueCondition_Is_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.Condition;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueEquality_IsEqualTo_Boolean_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueEquality_IsEqualTo_Boolean_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueEquality_IsEqualTo_Bytes_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueEquality_IsEqualTo_Bytes_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueEquality_IsEqualTo_Character_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueEquality_IsEqualTo_Character_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueEquality_IsEqualTo_DateTimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueEquality_IsEqualTo_DateTimeValue_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.sql.Timestamp;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueEquality_IsEqualTo_DateValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueEquality_IsEqualTo_DateValue_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.sql.Timestamp;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueEquality_IsEqualTo_Number_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueEquality_IsEqualTo_Number_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueEquality_IsEqualTo_Object_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueEquality_IsEqualTo_Object_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.Locale;
 

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueEquality_IsEqualTo_String_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueEquality_IsEqualTo_String_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.sql.Time;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueEquality_IsEqualTo_TimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueEquality_IsEqualTo_TimeValue_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Time;
 

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueEquality_IsEqualTo_UUID_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueEquality_IsEqualTo_UUID_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.UUID;
 

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueEquality_IsFalse_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueEquality_IsFalse_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueEquality_IsTrue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueEquality_IsTrue_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueEquality_IsZero_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueEquality_IsZero_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueInequality_IsNotEqualTo_Boolean_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueInequality_IsNotEqualTo_Boolean_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueInequality_IsNotEqualTo_Bytes_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueInequality_IsNotEqualTo_Bytes_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueInequality_IsNotEqualTo_Character_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueInequality_IsNotEqualTo_Character_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueInequality_IsNotEqualTo_DateTimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueInequality_IsNotEqualTo_DateTimeValue_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.sql.Timestamp;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueInequality_IsNotEqualTo_DateValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueInequality_IsNotEqualTo_DateValue_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.sql.Timestamp;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueInequality_IsNotEqualTo_Number_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueInequality_IsNotEqualTo_Number_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueInequality_IsNotEqualTo_Object_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueInequality_IsNotEqualTo_Object_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.Locale;
 

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueInequality_IsNotEqualTo_String_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueInequality_IsNotEqualTo_String_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 import java.sql.Time;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueInequality_IsNotEqualTo_TimeValue_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueInequality_IsNotEqualTo_TimeValue_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Time;
 

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueInequality_IsNotEqualTo_UUID_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueInequality_IsNotEqualTo_UUID_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.UUID;
 

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueInequality_IsNotZero_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueInequality_IsNotZero_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueNullity_IsNotNull_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueNullity_IsNotNull_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueNullity_IsNull_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueNullity_IsNull_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueType_IsBoolean_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueType_IsBoolean_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueType_IsBytes_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueType_IsBytes_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueType_IsDateTime_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueType_IsDateTime_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Timestamp;
 

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueType_IsDate_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueType_IsDate_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Date;
 

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueType_IsNumber_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueType_IsNumber_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueType_IsOfAnyTypeIn_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueType_IsOfAnyTypeIn_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.Locale;
 

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueType_IsOfType_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueType_IsOfType_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.Locale;
 

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueType_IsText_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueType_IsText_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.WritableAssertionInfo;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueType_IsTime_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueType_IsTime_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Time;
 

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueType_IsUUID_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValueType_IsUUID_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.UUID;
 

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValuesNullity_HasOnlyNotNullValues_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValuesNullity_HasOnlyNotNullValues_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValuesNullity_HasOnlyNullValues_Test.java
+++ b/src/test/java/org/assertj/db/api/assertions/impl/AssertionsOnValuesNullity_HasOnlyNullValues_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.api.assertions.impl;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/test/java/org/assertj/db/database/h2/H2Database_DataSource_NSNSNS_Test.java
+++ b/src/test/java/org/assertj/db/database/h2/H2Database_DataSource_NSNSNS_Test.java
@@ -12,9 +12,9 @@
  */
 package org.assertj.db.database.h2;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
 import static org.assertj.db.output.Outputs.output;
-import static org.junit.Assert.fail;
 
 import java.io.ByteArrayOutputStream;
 

--- a/src/test/java/org/assertj/db/database/h2/H2Database_JdbcUrl_NSNSNS_Test.java
+++ b/src/test/java/org/assertj/db/database/h2/H2Database_JdbcUrl_NSNSNS_Test.java
@@ -12,9 +12,9 @@
  */
 package org.assertj.db.database.h2;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
 import static org.assertj.db.output.Outputs.output;
-import static org.junit.Assert.fail;
 
 import java.io.ByteArrayOutputStream;
 

--- a/src/test/java/org/assertj/db/database/sqlite/SqliteDatabase_DataSource_NSNSNS_Test.java
+++ b/src/test/java/org/assertj/db/database/sqlite/SqliteDatabase_DataSource_NSNSNS_Test.java
@@ -12,9 +12,9 @@
  */
 package org.assertj.db.database.sqlite;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
 import static org.assertj.db.output.Outputs.output;
-import static org.junit.Assert.fail;
 
 import java.io.ByteArrayOutputStream;
 

--- a/src/test/java/org/assertj/db/database/sqlite/SqliteDatabase_JdbcUrl_NSNSNS_Test.java
+++ b/src/test/java/org/assertj/db/database/sqlite/SqliteDatabase_JdbcUrl_NSNSNS_Test.java
@@ -12,9 +12,9 @@
  */
 package org.assertj.db.database.sqlite;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
 import static org.assertj.db.output.Outputs.output;
-import static org.junit.Assert.fail;
 
 import java.io.ByteArrayOutputStream;
 

--- a/src/test/java/org/assertj/db/navigation/InstantiationError_Test.java
+++ b/src/test/java/org/assertj/db/navigation/InstantiationError_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.navigation;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import java.lang.reflect.Field;
 

--- a/src/test/java/org/assertj/db/navigation/ToChange_ChangeOfCreationOnTable_Integer_Test.java
+++ b/src/test/java/org/assertj/db/navigation/ToChange_ChangeOfCreationOnTable_Integer_Test.java
@@ -13,9 +13,9 @@
 package org.assertj.db.navigation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
 import static org.assertj.db.output.Outputs.output;
-import static org.junit.Assert.fail;
 
 import java.lang.reflect.Field;
 import java.util.List;

--- a/src/test/java/org/assertj/db/navigation/ToChange_ChangeOfCreationOnTable_Test.java
+++ b/src/test/java/org/assertj/db/navigation/ToChange_ChangeOfCreationOnTable_Test.java
@@ -13,9 +13,9 @@
 package org.assertj.db.navigation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
 import static org.assertj.db.output.Outputs.output;
-import static org.junit.Assert.fail;
 
 import java.lang.reflect.Field;
 import java.util.List;

--- a/src/test/java/org/assertj/db/navigation/ToChange_ChangeOfCreation_Integer_Test.java
+++ b/src/test/java/org/assertj/db/navigation/ToChange_ChangeOfCreation_Integer_Test.java
@@ -13,9 +13,9 @@
 package org.assertj.db.navigation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
 import static org.assertj.db.output.Outputs.output;
-import static org.junit.Assert.fail;
 
 import java.lang.reflect.Field;
 import java.util.List;

--- a/src/test/java/org/assertj/db/navigation/ToChange_ChangeOfCreation_Test.java
+++ b/src/test/java/org/assertj/db/navigation/ToChange_ChangeOfCreation_Test.java
@@ -13,9 +13,9 @@
 package org.assertj.db.navigation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
 import static org.assertj.db.output.Outputs.output;
-import static org.junit.Assert.fail;
 
 import java.lang.reflect.Field;
 import java.util.List;

--- a/src/test/java/org/assertj/db/navigation/ToChange_ChangeOfDeletionOnTable_Integer_Test.java
+++ b/src/test/java/org/assertj/db/navigation/ToChange_ChangeOfDeletionOnTable_Integer_Test.java
@@ -13,9 +13,9 @@
 package org.assertj.db.navigation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
 import static org.assertj.db.output.Outputs.output;
-import static org.junit.Assert.fail;
 
 import java.lang.reflect.Field;
 import java.util.List;

--- a/src/test/java/org/assertj/db/navigation/ToChange_ChangeOfDeletionOnTable_Test.java
+++ b/src/test/java/org/assertj/db/navigation/ToChange_ChangeOfDeletionOnTable_Test.java
@@ -13,9 +13,9 @@
 package org.assertj.db.navigation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
 import static org.assertj.db.output.Outputs.output;
-import static org.junit.Assert.fail;
 
 import java.lang.reflect.Field;
 import java.util.List;

--- a/src/test/java/org/assertj/db/navigation/ToChange_ChangeOfDeletion_Integer_Test.java
+++ b/src/test/java/org/assertj/db/navigation/ToChange_ChangeOfDeletion_Integer_Test.java
@@ -13,9 +13,9 @@
 package org.assertj.db.navigation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
 import static org.assertj.db.output.Outputs.output;
-import static org.junit.Assert.fail;
 
 import java.lang.reflect.Field;
 import java.util.List;

--- a/src/test/java/org/assertj/db/navigation/ToChange_ChangeOfDeletion_Test.java
+++ b/src/test/java/org/assertj/db/navigation/ToChange_ChangeOfDeletion_Test.java
@@ -13,9 +13,9 @@
 package org.assertj.db.navigation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
 import static org.assertj.db.output.Outputs.output;
-import static org.junit.Assert.fail;
 
 import java.lang.reflect.Field;
 import java.util.List;

--- a/src/test/java/org/assertj/db/navigation/ToChange_ChangeOfModificationOnTable_Integer_Test.java
+++ b/src/test/java/org/assertj/db/navigation/ToChange_ChangeOfModificationOnTable_Integer_Test.java
@@ -13,9 +13,9 @@
 package org.assertj.db.navigation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
 import static org.assertj.db.output.Outputs.output;
-import static org.junit.Assert.fail;
 
 import java.lang.reflect.Field;
 import java.util.List;

--- a/src/test/java/org/assertj/db/navigation/ToChange_ChangeOfModificationOnTable_Test.java
+++ b/src/test/java/org/assertj/db/navigation/ToChange_ChangeOfModificationOnTable_Test.java
@@ -13,9 +13,9 @@
 package org.assertj.db.navigation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
 import static org.assertj.db.output.Outputs.output;
-import static org.junit.Assert.fail;
 
 import java.lang.reflect.Field;
 import java.util.List;

--- a/src/test/java/org/assertj/db/navigation/ToChange_ChangeOfModification_Integer_Test.java
+++ b/src/test/java/org/assertj/db/navigation/ToChange_ChangeOfModification_Integer_Test.java
@@ -13,9 +13,9 @@
 package org.assertj.db.navigation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
 import static org.assertj.db.output.Outputs.output;
-import static org.junit.Assert.fail;
 
 import java.lang.reflect.Field;
 import java.util.List;

--- a/src/test/java/org/assertj/db/navigation/ToChange_ChangeOfModification_Test.java
+++ b/src/test/java/org/assertj/db/navigation/ToChange_ChangeOfModification_Test.java
@@ -13,9 +13,9 @@
 package org.assertj.db.navigation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
 import static org.assertj.db.output.Outputs.output;
-import static org.junit.Assert.fail;
 
 import java.lang.reflect.Field;
 import java.util.List;

--- a/src/test/java/org/assertj/db/navigation/ToChange_ChangeOnTableWithPks_Test.java
+++ b/src/test/java/org/assertj/db/navigation/ToChange_ChangeOnTableWithPks_Test.java
@@ -12,9 +12,9 @@
  */
 package org.assertj.db.navigation;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
 import static org.assertj.db.output.Outputs.output;
-import static org.junit.Assert.fail;
 
 import java.lang.reflect.Field;
 import java.util.List;

--- a/src/test/java/org/assertj/db/navigation/ToChange_ChangeOnTable_Integer_Test.java
+++ b/src/test/java/org/assertj/db/navigation/ToChange_ChangeOnTable_Integer_Test.java
@@ -13,9 +13,9 @@
 package org.assertj.db.navigation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
 import static org.assertj.db.output.Outputs.output;
-import static org.junit.Assert.fail;
 
 import java.lang.reflect.Field;
 import java.util.List;

--- a/src/test/java/org/assertj/db/navigation/ToChange_ChangeOnTable_Test.java
+++ b/src/test/java/org/assertj/db/navigation/ToChange_ChangeOnTable_Test.java
@@ -13,9 +13,9 @@
 package org.assertj.db.navigation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
 import static org.assertj.db.output.Outputs.output;
-import static org.junit.Assert.fail;
 
 import java.lang.reflect.Field;
 import java.util.List;

--- a/src/test/java/org/assertj/db/navigation/ToChange_Change_Integer_Test.java
+++ b/src/test/java/org/assertj/db/navigation/ToChange_Change_Integer_Test.java
@@ -13,9 +13,9 @@
 package org.assertj.db.navigation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
 import static org.assertj.db.output.Outputs.output;
-import static org.junit.Assert.fail;
 
 import java.lang.reflect.Field;
 import java.util.List;

--- a/src/test/java/org/assertj/db/navigation/ToChange_Change_Test.java
+++ b/src/test/java/org/assertj/db/navigation/ToChange_Change_Test.java
@@ -13,9 +13,9 @@
 package org.assertj.db.navigation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
 import static org.assertj.db.output.Outputs.output;
-import static org.junit.Assert.fail;
 
 import java.lang.reflect.Field;
 import java.util.List;

--- a/src/test/java/org/assertj/db/navigation/ToColumnFromChange_ColumnAmongTheModifiedOnes_Integer_Test.java
+++ b/src/test/java/org/assertj/db/navigation/ToColumnFromChange_ColumnAmongTheModifiedOnes_Integer_Test.java
@@ -12,9 +12,9 @@
  */
 package org.assertj.db.navigation;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
 import static org.assertj.db.output.Outputs.output;
-import static org.junit.Assert.fail;
 
 import java.lang.reflect.Field;
 import java.math.BigDecimal;

--- a/src/test/java/org/assertj/db/navigation/ToColumnFromChange_ColumnAmongTheModifiedOnes_String_Test.java
+++ b/src/test/java/org/assertj/db/navigation/ToColumnFromChange_ColumnAmongTheModifiedOnes_String_Test.java
@@ -12,9 +12,9 @@
  */
 package org.assertj.db.navigation;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
 import static org.assertj.db.output.Outputs.output;
-import static org.junit.Assert.fail;
 
 import java.lang.reflect.Field;
 import java.math.BigDecimal;

--- a/src/test/java/org/assertj/db/navigation/ToColumnFromChange_ColumnAmongTheModifiedOnes_Test.java
+++ b/src/test/java/org/assertj/db/navigation/ToColumnFromChange_ColumnAmongTheModifiedOnes_Test.java
@@ -12,9 +12,9 @@
  */
 package org.assertj.db.navigation;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
 import static org.assertj.db.output.Outputs.output;
-import static org.junit.Assert.fail;
 
 import java.lang.reflect.Field;
 import java.math.BigDecimal;

--- a/src/test/java/org/assertj/db/navigation/ToColumn_Column_Integer_Test.java
+++ b/src/test/java/org/assertj/db/navigation/ToColumn_Column_Integer_Test.java
@@ -12,9 +12,9 @@
  */
 package org.assertj.db.navigation;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
 import static org.assertj.db.output.Outputs.output;
-import static org.junit.Assert.fail;
 
 import java.lang.reflect.Field;
 import java.math.BigDecimal;

--- a/src/test/java/org/assertj/db/navigation/ToColumn_Column_String_Test.java
+++ b/src/test/java/org/assertj/db/navigation/ToColumn_Column_String_Test.java
@@ -12,9 +12,9 @@
  */
 package org.assertj.db.navigation;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
 import static org.assertj.db.output.Outputs.output;
-import static org.junit.Assert.fail;
 
 import java.lang.reflect.Field;
 import java.math.BigDecimal;

--- a/src/test/java/org/assertj/db/navigation/ToColumn_Column_Test.java
+++ b/src/test/java/org/assertj/db/navigation/ToColumn_Column_Test.java
@@ -13,9 +13,9 @@
 package org.assertj.db.navigation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
 import static org.assertj.db.output.Outputs.output;
-import static org.junit.Assert.fail;
 
 import java.lang.reflect.Field;
 import java.math.BigDecimal;

--- a/src/test/java/org/assertj/db/navigation/ToRow_Row_Integer_Test.java
+++ b/src/test/java/org/assertj/db/navigation/ToRow_Row_Integer_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.navigation;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import java.lang.reflect.Field;
 import java.math.BigDecimal;

--- a/src/test/java/org/assertj/db/navigation/ToRow_Row_Test.java
+++ b/src/test/java/org/assertj/db/navigation/ToRow_Row_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.navigation;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import java.lang.reflect.Field;
 import java.math.BigDecimal;

--- a/src/test/java/org/assertj/db/navigation/ToValueFromRow_Value_String_Test.java
+++ b/src/test/java/org/assertj/db/navigation/ToValueFromRow_Value_String_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.db.navigation;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import java.lang.reflect.Field;
 import java.math.BigDecimal;

--- a/src/test/java/org/assertj/db/navigation/ToValue_Value_Integer_Test.java
+++ b/src/test/java/org/assertj/db/navigation/ToValue_Value_Integer_Test.java
@@ -12,9 +12,9 @@
  */
 package org.assertj.db.navigation;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
 import static org.assertj.db.output.Outputs.output;
-import static org.junit.Assert.fail;
 
 import java.lang.reflect.Field;
 import java.math.BigDecimal;

--- a/src/test/java/org/assertj/db/navigation/ToValue_Value_Test.java
+++ b/src/test/java/org/assertj/db/navigation/ToValue_Value_Test.java
@@ -12,9 +12,9 @@
  */
 package org.assertj.db.navigation;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.db.api.Assertions.assertThat;
 import static org.assertj.db.output.Outputs.output;
-import static org.junit.Assert.fail;
 
 import java.lang.reflect.Field;
 import java.math.BigDecimal;

--- a/src/test/java/org/assertj/db/output/OutputterException_Test.java
+++ b/src/test/java/org/assertj/db/output/OutputterException_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.output;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.io.File;
 

--- a/src/test/java/org/assertj/db/type/Order_Equals_Test.java
+++ b/src/test/java/org/assertj/db/type/Order_Equals_Test.java
@@ -12,8 +12,7 @@
  */
 package org.assertj.db.type;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.assertj.db.common.AbstractTest;
 import org.assertj.db.type.Table.Order;
@@ -31,12 +30,12 @@ public class Order_Equals_Test extends AbstractTest {
    */
   @Test
   public void test_result_of_equals() {
-    assertTrue(Order.asc("test").equals(Order.asc("test")));
-    assertFalse(Order.asc("test").equals(Order.asc("testt")));
-    assertFalse(Order.asc("test").equals(Order.desc("test")));
-    assertTrue(Order.asc(null).equals(Order.asc(null)));
-    assertFalse(Order.asc("test").equals(Order.asc(null)));
-    assertFalse(Order.asc(null).equals(Order.asc("test")));
-    assertFalse(Order.asc("test").equals("test"));
+    assertThat(Order.asc("test").equals(Order.asc("test"))).isTrue();
+    assertThat(Order.asc("test").equals(Order.asc("testt"))).isFalse();
+    assertThat(Order.asc("test").equals(Order.desc("test"))).isFalse();
+    assertThat(Order.asc(null).equals(Order.asc(null))).isTrue();
+    assertThat(Order.asc("test").equals(Order.asc(null))).isFalse();
+    assertThat(Order.asc(null).equals(Order.asc("test"))).isFalse();
+    assertThat(Order.asc("test").equals("test")).isFalse();
   }
 }

--- a/src/test/java/org/assertj/db/type/lettercase/LetterCase_Exception_Test.java
+++ b/src/test/java/org/assertj/db/type/lettercase/LetterCase_Exception_Test.java
@@ -12,7 +12,7 @@
  */
 package org.assertj.db.type.lettercase;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.db.common.AbstractTest;

--- a/src/test/java/org/assertj/db/util/Values_AreEqual_UUID_And_String_Test.java
+++ b/src/test/java/org/assertj/db/util/Values_AreEqual_UUID_And_String_Test.java
@@ -12,8 +12,7 @@
  */
 package org.assertj.db.util;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.UUID;
 
@@ -32,14 +31,14 @@ public class Values_AreEqual_UUID_And_String_Test {
    */
   @Test
   public void test_are_equal_for_UUIDs() {
-    assertTrue(Values.areEqual(UUID.fromString("88838129-291E-40A9-A94C-A15BE36CF7C3"),
-      "88838129-291E-40A9-A94C-A15BE36CF7C3"));
-    assertFalse(Values.areEqual(UUID.fromString("88838129-291E-40A9-A94C-A15BE36CF7C3"),
-      null));
-    assertTrue(Values.areEqual((UUID) null,
-      (String) null));
-    assertFalse(Values.areEqual((UUID) null,
-      "88838129-291E-40A9-A94C-A15BE36CF7C3"));
+    assertThat(Values.areEqual(UUID.fromString("88838129-291E-40A9-A94C-A15BE36CF7C3"),
+      "88838129-291E-40A9-A94C-A15BE36CF7C3")).isTrue();
+    assertThat(Values.areEqual(UUID.fromString("88838129-291E-40A9-A94C-A15BE36CF7C3"),
+      null)).isFalse();
+    assertThat(Values.areEqual((UUID) null,
+      (String) null)).isTrue();
+    assertThat(Values.areEqual((UUID) null,
+      "88838129-291E-40A9-A94C-A15BE36CF7C3")).isFalse();
   }
 
   /**


### PR DESCRIPTION
This solves https://github.com/assertj/assertj-db/issues/332

I used OpenRewrite as suggested by @scordio ; though not the recipe suggested as it was a major refactoring of the code base beyond the scope of the ticket.
Altering the code on a large scale was quite fast with that tool, I did liked it, great tool.

To find the right recipes, I did spent some time analyzing what needed changes though.
There was only three types of old assertions that I found :

- A few `org.junit.Assert.assertTrue`
- A few `org.junit.Assert.assertFalse`
- Lots of `org.junit.Assert.fail`

The first two were those I saw when working on https://github.com/assertj/assertj-db/issues/329 and that's what initiated my suggestion.
There were very few; I just happened to find by accident the only two classes that had them (Order_Equals_Test / Values_AreEqual_UUID_And_String_Test).
All the other files changed were using `org.junit.Assert.fail` in `try/fail/catch` blocks

I spent some more time with OpenRewrite to see if I could change the `try/fail/catch` blocks to one of the Throwable-related AssertJ assertions.
I did find a recipe : https://docs.openrewrite.org/recipes/java/testing/assertj/junittryfailtoassertthatthrownby
However it seems to only work with empty `catch` blocks
And beside that, there are multiple ways in AssertJ to assert Throwables. This may not have been the one you would have chosen.
So I left `try/fail/catch` as is for now.

I also played with the recipe to replace `Assertions.assertThat` by the static import.
It works, but i realized two things :
- This seems to be the main usage in the code base - so this may be intended
- They were some leftovers : I think on the classes were both `assertThat` (from core and from db) have to coexist - so my second guess is the non-static import comes from that constraint

I left that as is for now too; though maybe it can now be solved thanks to https://github.com/assertj/assertj-db/issues/329 

As for OpenRewrite : I did not commit the config I used. Once run, I see it as dead code in the POM.
That's just me however, and I can alter the POM with the OpenRewrite config I used if you wish.

As for the recipes as I used : I did not find any that migrated Junit4 assertions to AssertJ ones.
There was however :

- One that migrate Junit4 assertions to Junit Jupiter ones
- And several recipes to migrate Junit Jupiter ones to AssertJ ones

For reference, I ended up with this :

```
      <plugin>
        <groupId>org.openrewrite.maven</groupId>
        <artifactId>rewrite-maven-plugin</artifactId>
        <version>6.29.0</version>
        <configuration>
          <exportDatatables>true</exportDatatables>
          <activeRecipes>
            <recipe>org.openrewrite.java.testing.junit5.AssertToAssertions</recipe>
            <recipe>org.openrewrite.java.testing.assertj.JUnitAssertTrueToAssertThat</recipe>
            <recipe>org.openrewrite.java.testing.assertj.JUnitAssertFalseToAssertThat</recipe>
            <recipe>org.openrewrite.java.testing.assertj.JUnitFailToAssertJFail</recipe>
          </activeRecipes>
        </configuration>
        <dependencies>
          <dependency>
            <groupId>org.openrewrite.recipe</groupId>
            <artifactId>rewrite-testing-frameworks</artifactId>
            <version>3.27.0</version>
          </dependency>
        </dependencies>
      </plugin>
```

If there is any interest, I'm willing to do more test-related refactorings; I have done this kind of work before.